### PR TITLE
github action workflow 수정

### DIFF
--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -16,6 +16,8 @@ jobs:
           MYSQL_DATABASE: blog
           MYSQL_USER: hsjang
           MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
     steps:
       - uses: actions/checkout@v2
       - name: Install NPM Dependencies

--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Test
         env:
-          MYSQL_CONNECTION_URL: mysql://hsjang:password@mysql:3306/blog
+          MYSQL_CONNECTION_URL: mysql://hsjang:password@127.0.0.1:3306/blog
         run: npm run test
 
       - name: Deploy

--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   job:
     runs-on: ubuntu-latest
-    container: node:12
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/production-ci.yml
+++ b/.github/workflows/production-ci.yml
@@ -27,8 +27,6 @@ jobs:
           npm ci
 
       - name: Test
-        env:
-          MYSQL_CONNECTION_URL: mysql://hsjang:password@127.0.0.1:3306/blog
         run: npm run test
 
       - name: Deploy

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -28,6 +28,4 @@ jobs:
           npm ci
 
       - name: Test
-        env:
-          MYSQL_CONNECTION_URL: mysql://hsjang:password@127.0.0.1:3306/blog
         run: npm run test

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -27,5 +27,5 @@ jobs:
 
       - name: Test
         env:
-          MYSQL_CONNECTION_URL: mysql://hsjang:password@mysql:3306/blog
+          MYSQL_CONNECTION_URL: mysql://hsjang:password@127.0.0.1:3306/blog
         run: npm run test

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   job:
     runs-on: ubuntu-latest
-    container: node:12
     services:
       mysql:
         image: mysql:5.7

--- a/.github/workflows/stage-ci.yml
+++ b/.github/workflows/stage-ci.yml
@@ -17,6 +17,8 @@ jobs:
           MYSQL_DATABASE: blog
           MYSQL_USER: hsjang
           MYSQL_PASSWORD: password
+        ports:
+          - 3306:3306
     steps:
       - uses: actions/checkout@v2
       - name: Install NPM Dependencies

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "deploy": "serverless deploy",
     "start": "serverless offline",
     "format": "prettier --write 'src/**/*.ts'",
-    "test": "mocha --require ts-node/register --exit -t 5000 src/**/__test__/*.spec.ts",
-    "test:local": "MYSQL_CONNECTION_URL=mysql://hsjang:password@127.0.0.1:3306/blog npm run test",
+    "test": "MYSQL_CONNECTION_URL=mysql://hsjang:password@127.0.0.1:3306/blog mocha --require ts-node/register --exit -t 5000 src/**/__test__/*.spec.ts",
     "coverage": "nyc --exclude='src/**/__test__' npm run test",
     "coverage:summary": "nyc --exclude='src/**/__test__' --reporter=text-summary npm run test",
     "logs": "serverless logs -t -f api -s prod --startTime 1m"


### PR DESCRIPTION
github action jobs가 별도의 container에서 실행되지 않고, runner machine에서 실행되도록 수정합니다.

mysql service container의 3306 포트를 열어줬습니다.

로컬과 CI가 같은 test script (npm run test)를 사용하도록 수정하고, package.json에서 test:local script를 삭제합니다.