### PR TITLE
포스트 뷰 정책을 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ First, setup mysql
 docker pull --platform linux/amd64 mysql:5.7
 
 docker run --platform linux/amd64 --name blog-mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=blog -e MYSQL_USER=hsjang -e MYSQL_PASSWORD=password -d mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+
+docker pull amazon/dynamodb-local
+
+docker run --rm --name blog-dynamo -p 8000:8000 -d amazon/dynamodb-local
 ```
 
 And then run test script

--- a/src/database/dynamo/__test__/index.spec.ts
+++ b/src/database/dynamo/__test__/index.spec.ts
@@ -1,10 +1,10 @@
 import { DynamoDB } from "@aws-sdk/client-dynamodb";
 
-import { postViewedIP } from "../postViewedIP";
+import { postViewedUser } from "../postViewedUser";
 
 const client = new DynamoDB({ region: "ap-northeast-2", endpoint: process.env.DYNAMODB_ENDPOINT });
 
-const tables = [postViewedIP];
+const tables = [postViewedUser];
 
 before(async () => {
   for (const table of tables) {

--- a/src/database/dynamo/postViewedUser.ts
+++ b/src/database/dynamo/postViewedUser.ts
@@ -1,21 +1,21 @@
 import { Table } from "./base";
 
 interface Properties {
-  ip: string;
+  userId: string;
   postId: string;
   expiredAt: number;
 }
 
-class PostViewedIP extends Table {
+class PostViewedUser extends Table {
   constructor() {
     super({
-      TableName: "post_viewed_ip",
+      TableName: "post_viewed_user",
       KeySchema: [
-        { AttributeName: "ip", KeyType: "HASH" },
+        { AttributeName: "userId", KeyType: "HASH" },
         { AttributeName: "postId", KeyType: "RANGE" },
       ],
       AttributeDefinitions: [
-        { AttributeName: "ip", AttributeType: "S" },
+        { AttributeName: "userId", AttributeType: "S" },
         { AttributeName: "postId", AttributeType: "S" },
       ],
     });
@@ -34,4 +34,4 @@ class PostViewedIP extends Table {
   }
 }
 
-export const postViewedIP = new PostViewedIP();
+export const postViewedUser = new PostViewedUser();


### PR DESCRIPTION
AS-IS
- 기존엔 IP를 기반으로 트래킹하고, increase를 제한했음.

TO-BE
- 프론트엔드에서 첫 접속 유저의 경우 uuid를 생성해서 local storage에 저장하고, 그 id를 활용해서 트래킹함.

추가
- userId를 body가 아니라 query parameter로 받도록 수정함. https://github.com/hoseung-only/blog-post/commit/6af280122a73530b238a54be8b807c27748e3d91 참고.